### PR TITLE
Adding Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+before_script:
+  - sudo apt-get update -q
+  - sudo apt-get install -y expect libgtk2.0-dev libgtkglext1-dev
+script:
+  - |
+    expect <<SCRIPT
+    spawn ./install
+    set timeout 3600
+    expect "Choice: "
+    send -- "1\r"
+    expect "Enter Install location"
+    send -- "\r"
+    expect eof
+    SCRIPT


### PR DESCRIPTION
Configuration for [Travis CI](https://travis-ci.org/) which builds gdis. Good for confirming that gdis builds fine with the listed dependencies after each GitHub push.

Travis CI uses Ubuntu 14.04, so this build doesn't do anything fancy except for scripting with [expect](http://expect.sourceforge.net/).
