### PR TITLE
FIX scrambled model display with plots

### DIFF
--- a/src/plots.c
+++ b/src/plots.c
@@ -107,6 +107,9 @@ void plot_prepare_data(struct plot_pak *plot){
 
         }
 	/* TODO: FREQ: add intensities */
+	/* TODO: how to signal task is completed?*/
+	plot->task->progress=100.0;/*job done*/
+	plot->task->status=COMPLETED;
         plot->data_changed=FALSE;/*protect data until changed*/
 }
 void plot_load_data(struct plot_pak *plot,struct task_pak *task){
@@ -123,11 +126,14 @@ void plot_load_data(struct plot_pak *plot,struct task_pak *task){
 if(plot->data_changed==FALSE) return;/*we do not need to reload data*/
 	/* TODO: prevent update while reading frame? */
 	g_assert(plot != NULL);
-	if(plot->plot_mask==0) return;/*no data to crunch*/
 	g_assert(plot->model != NULL);
 /* simply use model provided in plot */
 	model=plot->model;
-	if(model->num_frames<2) return;/*no frame -> skip this part*/
+	plot->task=task;
+	if((model->num_frames<2)||(plot->plot_mask==0)) {
+		task->progress=50.0;/*job half done (that was fast)*/
+		return;/*skip this part*/
+	}
 	/*open file*/
         fp=fopen(model->filename, "r");
         if (!fp){
@@ -303,6 +309,7 @@ if(plot->data_changed==FALSE) return;/*we do not need to reload data*/
 	read_raw_frame(fp,cur_frame,model);/*here?*/
         fclose(fp);
 	/* all done */
+	task->progress=50.0;/*job half done*/
 }
 /***************/
 /* energy plot */

--- a/src/plots.h
+++ b/src/plots.h
@@ -73,6 +73,7 @@ struct plot_pak {
         gboolean auto_x;
         gboolean auto_y;
         gboolean data_changed;
+	struct task_pak *task;/*attached task*/
 };
 
 /* prototypes */


### PR DESCRIPTION
Hello,

This is a fix for the problem of crazy structure display (which was not limited to arc files as I first though).
The problem was that the display was ready and updated *before* the thread for initializing plots data was finished. Since that thread was loading all frames, display was picking whichever frame was currently under process.
Fix is simply to wait for the thread to finish processing frames.

I also modify the file_arc.c to read energy (when available). 
The new version contains a lot of rewriting to get rid of tokenize calls, while that was maybe not that necessary.

Sincerely,