### PR TITLE
add band/dos to file_castep.c

### DIFF
--- a/src/file_castep.c
+++ b/src/file_castep.c
@@ -500,6 +500,7 @@ gint read_castep_out(gchar *filename, struct model_pak *model)
 {
 gint frame;
 gchar **buff, line[LINELEN], *text;
+gboolean band_structure;
 FILE *fp;
 
 if (g_strrstr(filename, ".cell") != NULL)
@@ -513,7 +514,9 @@ if (!fp)
 model->construct_pbc = TRUE;
 model->periodic = 3;
 model->fractional = TRUE;
-  
+
+band_structure=FALSE;/*switch for bandstructure reading*/
+
 frame=0;
 while (!fgetline(fp, line))
   {
@@ -541,7 +544,10 @@ while (!fgetline(fp, line))
       property_add_ranked(2, "Calculation", "Optimisation", model);
     else if (g_ascii_strncasecmp(*(buff+1), "single point energy", 19) == 0)
       property_add_ranked(2, "Calculation", "Single Point", model);
-    else
+    else if (g_ascii_strncasecmp(*(buff+1), "band structure", 14) == 0){
+      property_add_ranked(2, "Calculation", "Band Structure", model);
+      band_structure=TRUE;
+    }else
       property_add_ranked(2, "Calculation", *(buff+1), model);
     g_strfreev(buff);
     }
@@ -584,7 +590,111 @@ while (!fgetline(fp, line))
     }
   }
 
+fclose(fp);/*for some reason it seems that castep files are not closed after read?*/
+
+if(band_structure) {/*try to read band structure information, if any.*/
+	gint ispin=0;
+	gint ik=0;
+	gint ib=0;
+	gdouble xi,yi,zi;
+	gdouble *x,*y,*z;
+	gdouble ev,evmin,evmax;
+	gdouble dist=0.;
+	gchar *ptr=NULL;
+	gchar *band_filename=g_strdup (filename);
+	ptr=g_strrstr (band_filename,".castep");
+	if(ptr==NULL) goto castep_done;
+	sprintf(ptr,".bands");
+	fp = fopen(band_filename, "rt");
+	if(!fp) goto castep_done;
+	/*get number of kpoints*/
+	if(fgetline(fp, line)) goto castep_done;
+	sscanf(line,"Number of k-points %d",&(model->nkpoints));
+	if(fgetline(fp, line)) goto castep_done;
+	sscanf(line,"Number of spin components %d",&ispin);
+	if(ispin>1) model->spin_polarized=TRUE;
+	if(fgetline(fp, line)) goto castep_done;
+	/*skip number of electrons*/
+	if(fgetline(fp, line)) goto castep_done;
+	sscanf(line,"Number of eigenvalues %d",&(model->nbands));
+	if(fgetline(fp, line)) goto castep_done;
+	sscanf(line,"Fermi energy (%*[^)]) %lf",&(model->efermi));
+	while (!fgetline(fp, line)) if (g_strrstr(line, "K-point") != NULL) break;
+	if(!line) goto castep_done;
+	model->kpts_d=g_malloc((model->nkpoints)*sizeof(gdouble));
+	x=g_malloc((model->nkpoints)*sizeof(gdouble));
+	y=g_malloc((model->nkpoints)*sizeof(gdouble));
+	z=g_malloc((model->nkpoints)*sizeof(gdouble));
+	model->band_up=g_malloc((model->nkpoints*model->nbands)*sizeof(gdouble));
+	evmin=0.;evmax=0.;
+	while(line){
+		sscanf(line,"K-point  %i %lf %lf %lf %*f",&ik,&xi,&yi,&zi);
+		ik--;
+		/*kpts are *not* in order*/
+		x[ik]=xi;
+		y[ik]=yi;
+		z[ik]=zi;
+		/*read component 1*/
+		if(fgetline(fp, line)) break;
+		/* line should contain "Spin component 1", skipping */
+		ib=0;
+		while(ib<model->nbands) {
+			if(fgetline(fp, line)) break;
+			sscanf(line," %lf",&(ev));
+			if(ev<evmin) evmin=ev;
+			if(ev>evmax) evmax=ev;
+			model->band_up[ik*(model->nbands)+ib]=ev;
+			ib++;
+		}
+		if(fgetline(fp, line)) break;
+		if(model->spin_polarized){/*read component 2*/
+		}
+	}
+	xi=x[0];yi=y[0];zi=z[0];dist=0.;
+	for(ik=0;ik<model->nkpoints;ik++){
+		/*calculate distances*/
+		dist+=sqrt((x[ik]-xi)*(x[ik]-xi)+(y[ik]-yi)*(y[ik]-yi)+(z[ik]-zi)*(z[ik]-zi));
+		model->kpts_d[ik]=dist;
+		xi=x[ik];yi=y[ik];zi=z[ik];
+	}
+	g_free(x);
+	g_free(y);
+	g_free(z);
+	fclose(fp);
+	g_free(band_filename);
+/* BAND reading is done, now let's calculate DOS
+ * because CASTEP does not provide it directly..*/
+  if(model->nbands>2)
+  {
+/*we want DOS_NB DOS using a gaussian smearing of SIGMA (in au)*/
+#define DOS_NB 1000
+#define SIGMA 0.005
+gdouble emin=((int)(evmin*10.))/10.;
+gdouble emax=((int)(0.5+evmax*10.))/10.;
+gdouble dos;
+gdouble de;
+gdouble delta;
+int i;
+	model->ndos=DOS_NB;
+	model->dos_eval=g_malloc(DOS_NB*sizeof(gdouble));
+	model->dos_spin_up=g_malloc(DOS_NB*sizeof(gdouble));
+	for(i=0;i<DOS_NB;++i){
+		model->dos_eval[i]=emin+i*(emax-emin)/DOS_NB;
+		dos=0.;
+		for(ik=0;ik<model->nkpoints;ik++)
+			for(ib=0;ib<model->nbands;ib++){
+				de=model->dos_eval[i]-model->band_up[ik*(model->nbands)+ib];
+				de=de/SIGMA;
+				delta=exp(-1.0*de*de)/(sqrt(PI));/*GAUSSIAN SMEARING*/
+				dos+=delta/SIGMA;
+			}
+		model->dos_spin_up[i]=dos;
+	}
+  }
+  }
 /* done */
+
+castep_done:
 strcpy(model->filename, filename);
 g_free(model->basename);
 model->basename = parse_strip(filename);

--- a/src/file_castep.c
+++ b/src/file_castep.c
@@ -673,44 +673,7 @@ if(band_structure) {/*try to read band structure information, if any.*/
 	g_free(z);
 	fclose(fp);
 	g_free(band_filename);
-/* BAND reading is done, now let's calculate DOS
- * because CASTEP does not provide it directly..*/
-  if(model->nbands>2)
-  {
-/*we want DOS_NB DOS using a gaussian smearing of SIGMA (in au)*/
-#define DOS_NB 1000
-#define SIGMA 0.005
-gdouble emin=((int)(evmin*10.))/10.;
-gdouble emax=((int)(0.5+evmax*10.))/10.;
-gdouble dos;
-gdouble dos_dn;
-gdouble de;
-gdouble delta;
-int i;
-	model->ndos=DOS_NB;
-	model->dos_eval=g_malloc(DOS_NB*sizeof(gdouble));
-	model->dos_spin_up=g_malloc(DOS_NB*sizeof(gdouble));
-	if(model->spin_polarized) model->dos_spin_down=g_malloc(DOS_NB*sizeof(gdouble));
-	for(i=0;i<DOS_NB;++i){
-		model->dos_eval[i]=emin+i*(emax-emin)/DOS_NB;
-		dos=0.;dos_dn=0.;
-		for(ik=0;ik<model->nkpoints;ik++)
-			for(ib=0;ib<model->nbands;ib++){
-				de=model->dos_eval[i]-model->band_up[ik*(model->nbands)+ib];
-				de=de/SIGMA;
-				delta=exp(-1.0*de*de)/(sqrt(PI));/*GAUSSIAN SMEARING*/
-				dos+=delta/SIGMA;
-				if(model->spin_polarized){/*process spin down*/
-					de=model->dos_eval[i]-model->band_down[ik*(model->nbands)+ib];
-					de=de/SIGMA;
-					delta=exp(-1.0*de*de)/(sqrt(PI));/*GAUSSIAN SMEARING*/
-					dos_dn+=delta/SIGMA;
-				}
-			}
-		model->dos_spin_up[i]=dos;
-		if(model->spin_polarized) model->dos_spin_down[i]=dos_dn;
-	}
-  }
+/* BAND reading is done, DOS will be calculated somewhere else */
   }
 /* done */
 

--- a/src/gui_plots.c
+++ b/src/gui_plots.c
@@ -21,7 +21,6 @@ The GNU GPL can also be found at http://www.gnu.org
 */
 
 /* Plot simple data, such as energy, force, volume, etc. */
-#define BREAKPOINT __asm__("int $3")
 
 #include <math.h>
 #include <stdio.h>
@@ -46,11 +45,25 @@ The GNU GPL can also be found at http://www.gnu.org
 extern struct sysenv_pak sysenv;
 extern struct elem_pak elements[];
 struct plot_pak *plot;
-/* add widgets */
+/* text widgets */
 GtkWidget *plot_xmin;
 GtkWidget *plot_xmax;
 GtkWidget *plot_ymin;
 GtkWidget *plot_ymax;
+/* radio buttons */
+/*1st page*/
+GtkWidget *b_1_e;
+GtkWidget *b_1_f;
+GtkWidget *b_1_v;
+GtkWidget *b_1_p;
+/*2nd page*/
+GtkWidget *b_2_d;
+GtkWidget *b_2_b;
+GtkWidget *b_2_bd;
+/*3rd page*/
+GtkWidget *b_3_f;
+GtkWidget *b_3_r;
+
 
 /************************/
 /* plot toggle checkbox */
@@ -179,6 +192,7 @@ void plot_energy(){
 	plot->auto_y=TRUE;
 	auto_x_toggle(NULL,NULL);
 	auto_y_toggle(NULL,NULL);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_1_e),TRUE);
 	gui_relation_update(plot->model);
 }
 void plot_force(){
@@ -193,6 +207,7 @@ void plot_force(){
         plot->auto_y=TRUE;
         auto_x_toggle(NULL,NULL);
         auto_y_toggle(NULL,NULL);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_1_f),TRUE);
 	gui_relation_update(plot->model);
 }
 void plot_volume(){
@@ -207,6 +222,7 @@ void plot_volume(){
         plot->auto_y=TRUE;
         auto_x_toggle(NULL,NULL);
         auto_y_toggle(NULL,NULL);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_1_v),TRUE);
 	gui_relation_update(plot->model);
 }
 void plot_pressure(){
@@ -221,6 +237,7 @@ void plot_pressure(){
         plot->auto_y=TRUE;
         auto_x_toggle(NULL,NULL);
         auto_y_toggle(NULL,NULL);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_1_p),TRUE);
 	gui_relation_update(plot->model);
 }
 void plot_band(){
@@ -235,6 +252,7 @@ void plot_band(){
         plot->auto_y=TRUE;
         auto_x_toggle(NULL,NULL);
         auto_y_toggle(NULL,NULL);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_2_b),TRUE);
 	gui_relation_update(plot->model);
 }
 void plot_dos(){
@@ -249,6 +267,7 @@ void plot_dos(){
         plot->auto_y=TRUE;
         auto_x_toggle(NULL,NULL);
         auto_y_toggle(NULL,NULL);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_2_d),TRUE);
 	gui_relation_update(plot->model);
 }
 void plot_bandos(){
@@ -263,6 +282,7 @@ void plot_bandos(){
         plot->auto_y=TRUE;
         auto_x_toggle(NULL,NULL);
         auto_y_toggle(NULL,NULL);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_2_bd),TRUE);
 	gui_relation_update(plot->model);
 }
 void plot_frequency(){
@@ -277,6 +297,7 @@ void plot_frequency(){
         plot->auto_y=TRUE;
         auto_x_toggle(NULL,NULL);
         auto_y_toggle(NULL,NULL);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_3_f),TRUE);
 	gui_relation_update(plot->model);
 }
 void plot_raman(){
@@ -291,6 +312,7 @@ void plot_raman(){
         plot->auto_y=TRUE;
         auto_x_toggle(NULL,NULL);
         auto_y_toggle(NULL,NULL);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_3_r),TRUE);
 	gui_relation_update(plot->model);
 }
 void plot_none(){
@@ -606,18 +628,18 @@ void gui_plots_dialog(void){
 /* radio buttons */
 	new_radio_group(0, ionic_box, FF);
 /*by default any data not available _now_ will not be available later*/
-	button = add_radio_button("Energy / step", (gpointer) plot_energy,NULL);
-	if (plot->type == PLOT_ENERGY) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-	if (!(plot->plot_mask&PLOT_ENERGY)) gtk_widget_set_sensitive(button,FALSE);
-	button = add_radio_button("Forces / step", (gpointer) plot_force,NULL);
-	if (plot->type == PLOT_FORCE) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-	if (!(plot->plot_mask&PLOT_FORCE)) gtk_widget_set_sensitive(button,FALSE);
-	button = add_radio_button("Volume / step", (gpointer) plot_volume,NULL);
-	if (plot->type == PLOT_VOLUME) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-	if (!(plot->plot_mask&PLOT_VOLUME)) gtk_widget_set_sensitive(button,FALSE);
-	button = add_radio_button("Pressure / step", (gpointer) plot_pressure,NULL);
-	if (plot->type == PLOT_PRESSURE) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-	if (!(plot->plot_mask&PLOT_PRESSURE)) gtk_widget_set_sensitive(button,FALSE);
+	b_1_e = add_radio_button("Energy / step", (gpointer) plot_energy,NULL);
+	if (plot->type == PLOT_ENERGY) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_1_e), TRUE);
+	if (!(plot->plot_mask&PLOT_ENERGY)) gtk_widget_set_sensitive(b_1_e,FALSE);
+	b_1_f = add_radio_button("Forces / step", (gpointer) plot_force,NULL);
+	if (plot->type == PLOT_FORCE) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_1_f), TRUE);
+	if (!(plot->plot_mask&PLOT_FORCE)) gtk_widget_set_sensitive(b_1_f,FALSE);
+	b_1_v = add_radio_button("Volume / step", (gpointer) plot_volume,NULL);
+	if (plot->type == PLOT_VOLUME) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_1_v), TRUE);
+	if (!(plot->plot_mask&PLOT_VOLUME)) gtk_widget_set_sensitive(b_1_v,FALSE);
+	b_1_p = add_radio_button("Pressure / step", (gpointer) plot_pressure,NULL);
+	if (plot->type == PLOT_PRESSURE) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_1_p), TRUE);
+	if (!(plot->plot_mask&PLOT_PRESSURE)) gtk_widget_set_sensitive(b_1_p,FALSE);
 /*Set availability of the whole selection TODO: base on plot->plot_mask?*/
 	if(data->num_frames>1) gtk_widget_set_sensitive(ionic_box, TRUE);
 	else gtk_widget_set_sensitive(ionic_box, FALSE);
@@ -657,18 +679,18 @@ void gui_plots_dialog(void){
 	gtk_container_set_border_width(GTK_CONTAINER(vbox), PANEL_SPACING);
 /* radio buttons */
 	new_radio_group(0, electronic_box, FF);
-	button = add_radio_button("Density Of States", (gpointer) plot_dos,NULL);
-	if (plot->type == PLOT_DOS) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-	if (!(plot->plot_mask&PLOT_DOS)) gtk_widget_set_sensitive(button,FALSE);
-	button = add_radio_button("Band structure", (gpointer) plot_band,NULL);
-	if (plot->type == PLOT_BAND) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-	if (!(plot->plot_mask&PLOT_BAND)) gtk_widget_set_sensitive(button,FALSE);
-	button = add_radio_button("Band / DOS", (gpointer) plot_bandos,NULL);
-	if (plot->type == PLOT_BANDOS) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-	if ((plot->plot_mask&PLOT_BANDOS)^PLOT_BANDOS) gtk_widget_set_sensitive(button,FALSE);
+	b_2_d = add_radio_button("Density Of States", (gpointer) plot_dos,NULL);
+	if (plot->type == PLOT_DOS) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_2_d), TRUE);
+	if (!(plot->plot_mask&PLOT_DOS)) gtk_widget_set_sensitive(b_2_d,FALSE);
+	b_2_b = add_radio_button("Band structure", (gpointer) plot_band,NULL);
+	if (plot->type == PLOT_BAND) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_2_b), TRUE);
+	if (!(plot->plot_mask&PLOT_BAND)) gtk_widget_set_sensitive(b_2_b,FALSE);
+	b_2_bd = add_radio_button("Band / DOS", (gpointer) plot_bandos,NULL);
+	if (plot->type == PLOT_BANDOS) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_2_bd), TRUE);
+	if ((plot->plot_mask&PLOT_BANDOS)^PLOT_BANDOS) gtk_widget_set_sensitive(b_2_bd,FALSE);
 /* Set availability */
 /* TODO: DOS/BAND availability */
-	if (plot->plot_mask&PLOT_DOS) gtk_widget_set_sensitive(electronic_box, TRUE);
+	if (plot->plot_mask&PLOT_BANDOS) gtk_widget_set_sensitive(electronic_box, TRUE);
 	else gtk_widget_set_sensitive(electronic_box, FALSE);
 /* --- Page 3 -> TODO: Frequency */
         page = gtk_vbox_new(FALSE, PANEL_SPACING);
@@ -706,12 +728,12 @@ void gui_plots_dialog(void){
         gtk_container_set_border_width(GTK_CONTAINER(vbox), PANEL_SPACING);
 /* radio buttons */
         new_radio_group(0, frequency_box, FF);
-        button = add_radio_button("Vibrational", (gpointer) plot_frequency,NULL);
-        if (plot->type == PLOT_FREQUENCY) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-	if (!(plot->plot_mask&PLOT_FREQUENCY)) gtk_widget_set_sensitive(button,FALSE);
-        button = add_radio_button("Raman", (gpointer) plot_raman,NULL);
-        if (plot->type == PLOT_RAMAN) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-	if (!(plot->plot_mask&PLOT_RAMAN)) gtk_widget_set_sensitive(button,FALSE);
+        b_3_f = add_radio_button("Vibrational", (gpointer) plot_frequency,NULL);
+        if (plot->type == PLOT_FREQUENCY) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_3_f), TRUE);
+	if (!(plot->plot_mask&PLOT_FREQUENCY)) gtk_widget_set_sensitive(b_3_f,FALSE);
+        b_3_r = add_radio_button("Raman", (gpointer) plot_raman,NULL);
+        if (plot->type == PLOT_RAMAN) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(b_3_r), TRUE);
+	if (!(plot->plot_mask&PLOT_RAMAN)) gtk_widget_set_sensitive(b_3_r,FALSE);
 /* Set availability */
 /* TODO: FREQUENCY/RAMAN availability */
 	if (plot->plot_mask&PLOT_FREQUENCY) gtk_widget_set_sensitive(frequency_box, TRUE);


### PR DESCRIPTION
Hello!

I add a small parser for bands file produced during castep band structure calculations.
I also made a silly DOS "calculation" using a basic gaussian smearing. However I wonder if this should rather be available as an option in the plot gui (something like a "build DOS" button when DOS information is missing) instead of silently forcing it during the read of castep output... what is your opinion?

BTW if you need band structure calculation files from castep to be added to models, please let me know.

![dos_castep](https://user-images.githubusercontent.com/36496189/38021800-d139bc18-32b8-11e8-9390-5abad25b8228.png)

Sincerely,

PS: also fix radio button update in gui_plot.c.
