### PR TITLE
FIX clang now can compile GDIS!

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -423,6 +423,28 @@ sysenv.msb_on = TRUE;
 sysenv.apb_on = TRUE;
 sysenv.lmb_on = FALSE;
 sysenv.pib_on = FALSE;
+
+/*edit_dialog*/
+sysenv.cedit.edit_anim_n=0;
+sysenv.cedit.edit_chirality[0]=6.;
+sysenv.cedit.edit_chirality[1]=6.;
+sysenv.cedit.edit_length=1.44;
+sysenv.cedit.edit_basis[0]=NULL;
+sysenv.cedit.edit_basis[1]=NULL;
+sysenv.cedit.edit_spatial_colour[0]=1.0;
+sysenv.cedit.edit_spatial_colour[1]=0.0;
+sysenv.cedit.edit_spatial_colour[2]=0.0;
+sysenv.cedit.edit_label_colour[0]=1.0;
+sysenv.cedit.edit_label_colour[1]=1.0;
+sysenv.cedit.edit_label_colour[2]=1.0;
+sysenv.cedit.spatial_list=NULL;
+sysenv.cedit.spatial_tree=NULL;
+sysenv.cedit.spatial_selected=NULL;
+sysenv.cedit.diffract_model=NULL;
+/*edit_widget*/
+sysenv.cedit.apd_data=NULL;
+sysenv.cedit.apd_core=NULL;
+
 /* default to single model display */
 sysenv.mal = NULL;
 sysenv.displayed[0] = -1;

--- a/src/pak.h
+++ b/src/pak.h
@@ -120,6 +120,40 @@ gdouble ribbon_colour[3];
 gchar *morph_finish;
 };
 
+/********************/
+/* edit data --OVHPA*/
+/********************/
+struct edit_pak {
+gdouble tmat[9];
+gdouble tvec[3];
+gdouble edit_anim_n;
+gdouble edit_chirality[2];
+gdouble edit_length;
+gpointer edit_construct;
+gchar *edit_basis[2];
+#ifdef UNUSED_BUT_SET
+GtkWidget *elem_entry, *grid_dim, *grid_sep;
+#endif
+GtkWidget *axis_entry, *obj_entry, *periodicity_spin;
+GtkWidget *transmat[12];
+/* NEW */
+gdouble edit_spatial_colour[3];
+gdouble edit_label_colour[3];
+/*spatial*/
+GtkListStore *spatial_list;
+GtkWidget *spatial_tree;
+gpointer spatial_selected;
+/*diffract*/
+struct model_pak *diffract_model;
+GtkWidget *diffract_layer_total;
+GtkWidget *diffract_layer_order;
+/* globals for the atom properties dialog */
+GtkWidget *apd_label, *apd_type, *apd_charge, *apd_x, *apd_y, *apd_z;
+GtkWidget *apd_growth, *apd_region, *apd_translate;
+struct model_pak *apd_data;
+struct core_pak *apd_core;
+};
+
 /***********************/
 /* top level structure */
 /***********************/
@@ -202,6 +236,9 @@ gint apb_on;
 gint pib_on;
 gint lmb_on;
 gint mcb_on;
+
+/*NEW - edit pak is here*/
+struct edit_pak cedit;
 
 /* model related */
 gpointer active_model;
@@ -1059,7 +1096,7 @@ gint redraw_count;       /* current number of redraws */
 gint redraw_current;     /* current redraw time (micro-sec) */
 gint redraw_cumulative;  /* cumulative redraw time (micro-sec) */
 gint redraw_time;        /* average redraw time (micro-sec) */
-gboolean snapshot_eps;  /* save an eps image to file eps_file */
+gboolean snapshot_eps;   /* save an eps image to file eps_file */
 gchar *eps_file;         /* the said eps_file           --OVHPA*/
 gint fractional;
 guint periodic;


### PR DESCRIPTION
Dear Prof. Rohl,

I find the problem which prevent `clang` compiler from compiling gui_edit.c as you report on #19 :D 
The solution was in `gui_edit_dialog` function:
```C
p_i=0;
for(i=0;i<12;p_i++ , i++)
  g_signal_connect(GTK_OBJECT(CEDIT.transmat[i]), "changed",
  GTK_SIGNAL_FUNC(change_transmat), p_i);
```
with `change_transmat` defined as
```C
void change_transmat(GtkWidget *w, gint i)
{
const gchar *text;
text = gtk_entry_get_text(GTK_ENTRY(transmat[i]));
if (i < 9)
  tmat[i] = str_to_float(text);
else
  tvec[i-9] = str_to_float(text);
}
```
in which clang failed to get the relation between p_i and i.
Actually this relation was misleading to begin with. I now resolve on something less prone to errors, with calling from `gui_edit_dialog` function defined as:
```C
for(i=0;i<12;i++)
  g_signal_connect(GTK_OBJECT(CEDIT.transmat[i]), "changed",
    GTK_SIGNAL_FUNC(change_transmat), NULL);
```
while change_transmat function now updates every fields on each call:
```C
void change_transmat(GtkWidget *w)
{
gint i;
const gchar *text;
if(w==NULL) return;
  for(i=0;i<12;i++){
    text = gtk_entry_get_text(GTK_ENTRY(CEDIT.transmat[i]));
    if (i < 9)
      CEDIT.tmat[i] = str_to_float(text);
    else
      CEDIT.tvec[i-9] = str_to_float(text);
  }
}
```
While this is not equivalent I think we can afford to loose the little time needed to update 12 text fields instead of 1, and gain `clang` optimization.

**Additionally:**
I also modified the gui_edit.c file to have its disseminated global variables inside the external global variable `sysenv`.
I think this is more safe (and easy to follow) this way, but it is actually unrelated to this BUG.

Sincerely,





