### PR TITLE
FIX for gtkglext

### DIFF
--- a/src/gui_render.c
+++ b/src/gui_render.c
@@ -107,7 +107,6 @@ gchar *fn;
 
 fn = gtk_font_selection_dialog_get_font_name ((GtkFontSelectionDialog *) fsd);
 strcpy(sysenv.gl_fontname, fn);
-gl_font_free();
 redraw_canvas(ALL);
 }
 

--- a/src/gui_uspex.c
+++ b/src/gui_uspex.c
@@ -4067,7 +4067,7 @@ void uspex_gui_refresh(){
 			else num=uspex_gui.calc._nspecies;
 			for(i=0;i<uspex_gui.calc._var_nspecies;i++){
 				line=g_strdup(" ");
-				for(j=0;j<uspex_gui.calc._nmolecules;j++){
+				for(j=0;j<num;j++){
 					ptr=g_strdup_printf("%s %i",line,uspex_gui.calc.numSpecies[j+i*uspex_gui.calc._nmolecules]);
 					g_free(line);
 					line=ptr;

--- a/src/opengl.h
+++ b/src/opengl.h
@@ -89,9 +89,7 @@ void draw_arc(gdouble *, gdouble *, gdouble *);
 
 void gl_print_window(gchar *, gint, gint, struct canvas_pak *);
 void pango_print(const gchar *str, gint x, gint y, struct canvas_pak *canvas, guint font_size, gint rotate);
-void gl_print_world(gchar *, gdouble, gdouble, gdouble);
-
-void gl_font_free(void);
+void pango_print_world(gchar *str, gdouble x, gdouble y, gdouble z,struct canvas_pak *canvas);
 
 void stereo_init_window(struct canvas_pak *);
 gint stereo_expose_event(GtkWidget *, GdkEventExpose *);


### PR DESCRIPTION
This is an important fix for distributions which use a **gtkglext** version for which **gdk_gl_font_use_pango_font** have been removed.

The root of the problem was the [removal](https://www.mail-archive.com/gtkglext-list@gnome.org/msg00649.html) of **gdk_gl_font_use_pango_font** which had no actual (or practical) replacement. It impacted and continue to impact several package (including ghemical until [now](https://bugs.launchpad.net/ubuntu/+source/ghemical/+bug/786402) and gabedit on some [distributions](https://forums.opensuse.org/showthread.php/500042-How-do-I-get-the-package-gtkglext), both of which I sometimes use).

I choose to use a method which involves pango + cairo writing the text onto a buffer, then draw that buffer on the screen directly using `glDrawPixels`. This may not be the recommended method (according to forums writing text on a texture then placing it on the screen is better) but I think it is more appropriate.

Also the openGL part of the code:
```
glRasterPos3f(x,y,z);
glPixelZoom( 1, -1 );
glDrawPixels(width,height,GL_BGRA,GL_UNSIGNED_BYTE,surface_data);
```
is close to the original:
```
glRasterPos3f(x,y,z); 
glListBase(font_offset);
glCallLists(strlen(str), GL_UNSIGNED_BYTE, str);
```
The added `glPixelZoom` is required because for some reason `glDrawPixels` draw the buffer upside-down. ^^'

* This (I think) will allow users to install GDIS on most Linux distributions, regardless of the **gtkglext** version. For example the installation on Opensuse was really troublesome. 
* The other benefit is that error message `GdkGLExt-WARNING **: cannot load PangoFont` will not appear and all text will actually be displayed. The fonts are used "on time" and not preloaded, so it would even be theoretically possible to use several fonts on the same structure.
* Additionally, all fonts that can be list on GDIS font selection dialogue will now be available. On some distributions / configurations, only few fonts could actually display some text.
* Last but not least, the text display is now of `pango_layout_set_markup` type, which means we can add dynamical text that contain [pango markup language](https://developer.gnome.org/pygtk/stable/pango-markup-language.html). So we could have a <sup>14</sup>C labelled atom :D

However, should there be some trouble, please let me know.

PS: I'm committing this now, because we require it for the incoming workshop.
PPS: I also include some minor fixing (mostly to remove some of the warning messages).
