### PR TITLE
fix _BUG_ when launching uspex with a foreign local.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -25,6 +25,7 @@ The GNU GPL can also be found at http://www.gnu.org
 
 #include <signal.h>
 #include <stdio.h>
+#include <locale.h>
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
@@ -772,6 +773,8 @@ if (sysenv.canvas)
 
 /* main interface */
   gui_init(argc, argv);
+/* internationalization: set locale to C to avoid _BUG_*/
+setlocale(LC_ALL, "C");
 
 /* task update timer */
 /* TODO - put this in gui_widget_handler? */


### PR DESCRIPTION
This fixes a problem when launching GDIS from a computer with a LANG and/or LC_ALL global variable set as other than C.
In some language, specific format for numbers causes GDIS to parse input files incorrectly.

For example, in French, a decimal number is defined by digits separated by a coma.
This result in the following incorrect display:
![lang_fr](https://user-images.githubusercontent.com/36496189/59402017-c2f79000-8dd7-11e9-97ed-fa56a381687d.png)
note the comma for numbers as well as truncation to zero (Energy is -73,000000 eV).
Also the structure is not loaded properly and have a wrong number of atoms.
For information, this is the proper display:
![lang_c](https://user-images.githubusercontent.com/36496189/59402127-2386cd00-8dd8-11e9-83e2-fa3aa73a05ee.png)

The BUG is fixed by setting the local globally to "C", which should be cross-platform.
In the future, however, we should save the original locale in order to have proper translations for GDIS.
