### PR TITLE
workshop feedback

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -1800,18 +1800,25 @@ gboolean dumb_file_copy(gchar *f_src,gchar *f_dest){
 gchar *buffer;
 GError *error;
 gsize length;
-#ifdef DEBUG_DUMB_COPY
+#if DEBUG_DUMB_COPY
 fprintf(stdout,"copy %s into %s ... ",f_src,f_dest);
 #endif
 if(g_file_get_contents (f_src,&buffer,&length,&error)){
+if(error!=NULL) {/*who would set error on a success?*/
+#if DEBUG_DUMB_COPY
+	fprintf(stdout,"error#1=%s\n",error->message);
+#endif
+	g_error_free (error);
+	g_free(error);
+}
 	if(g_file_set_contents (f_dest,buffer,(gssize) length,&error)){
-#ifdef DEBUG_DUMB_COPY
+#if DEBUG_DUMB_COPY
 fprintf(stdout,"SUCCESS!\n");
 #endif
 		return TRUE;
 	}
 }
-#ifdef DEBUG_DUMB_COPY
+#if DEBUG_DUMB_COPY
 fprintf(stdout,"FAILED!\n");
 #endif
 fprintf(stderr,"Error during copy of %s into %s\nError code %i: %s",f_src,f_dest,error->code, error->message);

--- a/src/file.h
+++ b/src/file.h
@@ -83,6 +83,9 @@ gchar *file_extension_get(const gchar *);
 gint file_byte_size(const gchar *);
 gchar *file_find_program(const gchar *);
 
+gboolean dumb_file_copy(gchar *f_src,gchar *f_dest);
+gboolean dumb_dir_copy(gchar *src, gchar *dest);
+
 /* dialog control */
 void file_dialog(gchar *, gchar *, gint, 
                  gpointer (gchar *,  struct model_pak *), gint);

--- a/src/file_uspex.c
+++ b/src/file_uspex.c
@@ -2832,18 +2832,20 @@ fprintf(stdout,"}\n");
 /*END new*/
 				cur=_UO.ind[idx].gen;
 				if(c[num-1]<c_min[jdx]) c_min[jdx]=c[num-1];
+				if(cur==gen) c_col[num-1]=GRAPH_COLOR_GREEN;
+				else c_col[num-1]=GRAPH_COLOR_DEFAULT;
 				if(_UO.ind[idx].struct_number>0) {
 					c_idx[num-1]=_UO.ind[idx].struct_number;
 					c_sym[num-1]=GRAPH_SYMB_SQUARE;
+if((_UO.pictave)&&(_UO.ind[idx].atoms[_UO.calc->_nspecies-1]!=0)){
+		c_sym[num-1]=GRAPH_SYMB_DIAM;
+		c_col[num-1]=GRAPH_COLOR_BLUE;
+		gy.mixed_symbol=TRUE;/*special meaning of diam symbol should be preserved*/
+}
 				}else{
 					c_idx[num-1]=-1*idx;
 					c_sym[num-1]=GRAPH_SYMB_CROSS;
 					gy.mixed_symbol=TRUE;/*special meaning of cross symbol should be preserved*/
-				}
-				if(cur==gen){
-					c_col[num-1]=GRAPH_COLOR_GREEN;
-				}else{
-					c_col[num-1]=GRAPH_COLOR_DEFAULT;
 				}
 				gy.y=c;
 				gy.idx=c_idx;
@@ -3602,6 +3604,7 @@ gint read_output_uspex(gchar *filename, struct model_pak *model){
 	gdouble *c_min;
 	gint32 *c_idx;
 	graph_symbol *c_sym;
+	graph_color *c_col;
 	gint species_index;
 	/* results */
 	gint natoms=0;
@@ -4472,6 +4475,7 @@ fprintf(stdout,"}\n");
 					c=g_malloc(1*sizeof(gdouble));
 					c_idx=g_malloc(1*sizeof(gint32));
 					c_sym=g_malloc(1*sizeof(graph_symbol));
+					c_col=g_malloc(1*sizeof(graph_color));
 				}else{
 					c=g_malloc(num*sizeof(gdouble));
 					memcpy(c,gy.y,(num-1)*sizeof(gdouble));
@@ -4479,9 +4483,12 @@ fprintf(stdout,"}\n");
 					memcpy(c_idx,gy.idx,(num-1)*sizeof(gint32));
 					c_sym=g_malloc(num*sizeof(graph_symbol));
 					memcpy(c_sym,gy.symbol,(num-1)*sizeof(graph_symbol));
+					c_col=g_malloc(num*sizeof(graph_color));
+					memcpy(c_col,gy.sym_color,(num-1)*sizeof(graph_color));
 					g_free(gy.y);
 					g_free(gy.idx);
 					g_free(gy.symbol);
+					g_free(gy.sym_color);
 				}
 /*NEW: modify with the reference*/
 if(_UO.have_ref){
@@ -4506,6 +4513,7 @@ if(_UO.have_ref){
 }
 /*END new*/
 				if(c[num-1]<c_min[jdx]) c_min[jdx]=c[num-1];
+				c_col[num-1]=GRAPH_COLOR_DEFAULT;
 				if(_UO.ind[idx].struct_number>0) {
 					c_idx[num-1]=_UO.ind[idx].struct_number;
 					c_sym[num-1]=GRAPH_SYMB_SQUARE;
@@ -4514,15 +4522,21 @@ if(_UO.have_ref){
 					c_sym[num-1]=GRAPH_SYMB_CROSS;
 					gy.mixed_symbol=TRUE;/*special meaning of cross symbol should be preserved*/
 				}
+if((_UO.pictave)&&(_UO.ind[idx].atoms[_UO.calc->_nspecies-1]!=0)){
+                c_sym[num-1]=GRAPH_SYMB_DIAM;
+                c_col[num-1]=GRAPH_COLOR_BLUE;
+                gy.mixed_symbol=TRUE;/*special meaning of diam symbol should be preserved*/
+}
 				gy.y=c;
 				gy.idx=c_idx;
 				gy.symbol=c_sym;
+				gy.sym_color=c_col;
 				gy.type=GRAPH_XX_TYPE;
 			}
 			gy.y_size=num;
 			gy.color=GRAPH_COLOR_DEFAULT;
-			gy.sym_color=g_malloc0(num*sizeof(graph_color));
-			for(idx=0;idx<num;idx++) gy.sym_color[idx]=GRAPH_COLOR_DEFAULT;
+//			gy.sym_color=g_malloc0(num*sizeof(graph_color));
+//			for(idx=0;idx<num;idx++) gy.sym_color[idx]=GRAPH_COLOR_DEFAULT;
 			gy.line=GRAPH_LINE_NONE;/*FROM: 11a1ed*/
 			dat_graph_set_limits(0.,1.,min_E-0.05*(max_E-min_E),max_E+0.05*(max_E-min_E),_UO.graph_comp[species_index]);
 			dat_graph_add_y(gy,_UO.graph_comp[species_index]);

--- a/src/file_uspex.c
+++ b/src/file_uspex.c
@@ -2550,7 +2550,7 @@ void uspex_update_eref(uspex_output_struct *uspex_output){
 				if((spe_index==jdx)&&(_UO.ind[idx].atoms[jdx]==0)) isref=FALSE;
 			}
 			if(isref){
-				if((_UO.ind[idx].energy/_UO.ind[idx].natoms) <= ef_ref){
+				if((_UO.ind[idx].energy/_UO.ind[idx].natoms) < ef_ref){
 					ef_ref=_UO.ind[idx].energy/(gdouble)_UO.ind[idx].natoms;
 					_UO.ef_refs[spe_index]=_UO.ind[idx].energy;
 					_UO.natom_refs[spe_index]=_UO.ind[idx].natoms;
@@ -2813,7 +2813,8 @@ fprintf(stdout,"}\n");
 					if(_UO.ind[idx].energy<10000.000){
 						ef=_UO.ind[idx].energy;
 						for(spe_index=0;spe_index<tmp_nspecies;spe_index++)
-						ef-=_UO.ef_refs[spe_index]*(_UO.ind[idx].atoms[spe_index]/(gdouble)_UO.natom_refs[spe_index]);
+							ef-=_UO.ef_refs[spe_index]*(_UO.ind[idx].atoms[spe_index]/(gdouble)_UO.natom_refs[spe_index]);
+						ef/=_UO.ind[idx].natoms;/*FIX --OVHPA*/
 						c[num-1]=ef;
 						if(ef<min_E) min_E=ef;
 						if(ef>max_E) max_E=ef;
@@ -4496,6 +4497,7 @@ if(_UO.have_ref){
 					ef=_UO.ind[idx].energy;
 					for(spe_index=0;spe_index<tmp_nspecies;spe_index++)
 						ef-=_UO.ef_refs[spe_index]*(_UO.ind[idx].atoms[spe_index]/(gdouble)_UO.natom_refs[spe_index]);
+					ef/=_UO.ind[idx].natoms;/*FIX --OVHPA*/
 					c[num-1]=ef;
 					if(ef<min_E) min_E=ef;
 					if(ef>max_E) max_E=ef;

--- a/src/gl_graph.c
+++ b/src/gl_graph.c
@@ -1385,7 +1385,7 @@ if(graph->x_title){
   }
 }
 if(graph->y_title){
-  pango_print(graph->y_title,0,oy-0.33*dy,canvas,gl_fontsize,90);
+  pango_print(graph->y_title,0+gl_fontsize,oy-0.33*dy,canvas,gl_fontsize,90);
 }
 /*axis?*/
 }

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -1810,6 +1810,7 @@ GtkItemFactory *item;
 GdkColor colour;
 
 gtk_init(&argc, &argv);
+gdk_gl_init(&argc, &argv);
 gtk_gl_init(&argc, &argv);
 
 /* enforce true colour (fixes SG problems) */
@@ -2235,6 +2236,7 @@ gtk_paned_pack1(GTK_PANED(vpaned), sysenv.display_box, TRUE, TRUE);
 /* create the main drawing area */
 if (gl_init_visual())
   exit(1);
+
 canvas_init(sysenv.display_box);
 canvas_new(0, 0, sysenv.width, sysenv.height);
 

--- a/src/gui_plots.c
+++ b/src/gui_plots.c
@@ -290,11 +290,12 @@ void plot_cleanup(struct model_pak *model){
 	model->plots=FALSE;
 }
 void plot_quit(GtkWidget *w, gpointer data){
-	struct model_pak *model=data;
-	g_assert(model != NULL);
+	struct model_pak *model=sysenv.active_model;
+	if(data==NULL) return;/*no dialog*/
+	if(model==NULL) return;/*no model*/
 	/*cleanup plot mess*/
 	plot_cleanup(model);
-	dialog_destroy(w,model);
+	dialog_destroy(w,data);/*_BUG_ model is *NOT* a dialog!*/
 }
 /******************/
 /* start plotting */

--- a/src/gui_uspex.h
+++ b/src/gui_uspex.h
@@ -321,6 +321,7 @@ struct uspex_calc_gui{
 	gboolean have_result;
 	gboolean have_v1010;
 	gboolean have_octave;
+	gboolean copySpecific;/*NEW: copy the Specific directory*/
 	gint index;
 /*buttons*/
 	GUI_OBJ *button_save;

--- a/src/plots.c
+++ b/src/plots.c
@@ -662,7 +662,7 @@ dat_graph_set_type(GRAPH_YX_TYPE,plot->graph);/*<-note the inversion!!*/
 gx.x_size=model->nkpoints+1;/*ADD DOS origin for the first set*/
 gx.x=g_malloc(gx.x_size*sizeof(gdouble));
 gx.x[0]=-1.0*scale*plot->dos.ymax;
-for(idx=0;idx<gx.x_size;idx++) gx.x[idx+1]=model->kpts_d[idx];
+for(idx=0;idx<gx.x_size-1;idx++) gx.x[idx+1]=model->kpts_d[idx];/*FIX*/
 dat_graph_set_x(gx,plot->graph);
 g_free(gx.x);
 /*first set is DOS*/


### PR DESCRIPTION
Some modification after the USPEX 17th workshop, as reported by Dr. Marchal, who performed the GDIS installation in Rennes, France*; and the workshop participants.

Two important changes:

1. Modification contains a FIX to an openGL issue with software rendering, ill-configure system, or gtkgl flavour that lacks the GDK_GL_MODE_ACCUM capability. The issue was an improper display of the pango text (ie. it only appear briefly on every refresh event), due to a race condition with other openGL draws.
I switch the `pango_print` function to only use `cairo` function (the internal GTK drawing function). Unfortunately `cairo` is not so well integrated with GTK+-2.0, so should the text not being displayed properly, please let me know.

2. The convex hull COMP graphs for USPEX variable composition calculations was also modified to cope with the ones calculated by USPEX.
I notice however a tiny discrepancy (within the meV order, possibly due to truncation in Individuals file) in the determination of minimum structures for simple elements (ie A<sub>n</sub> or B<sub>m</sub> in the following equation). It is of no visible consequence in the display of convex hull, and reported stable composition are correct. 
I recommend to create a chem.in file containing reference energies calculated with a good, strong confidence, to eliminate the problem of USPEX internal reference.
The energy is now calculated, for a A<sub>x</sub>B<sub>y</sub> structure, as
> E<sub>f</sub> = E[A<sub>x</sub>B<sub>y</sub>] - ( x/n E[A<sub>n</sub>] + y/m E[B<sub>m</sub>] ) / ( x + y )


Some other requests have been voiced, but I will need a little longer to investigate ;) 


*Dr. Marchal also reported the incorrect behaviour that I fixed in the pull #26 

