### PR TITLE
gui_diffract: FIX the selection of peak from baseline or top value.

### DIFF
--- a/src/gl_graph.c
+++ b/src/gl_graph.c
@@ -583,6 +583,121 @@ if (graph->x_title) oy = canvas->y + canvas->height - 5*gl_fontsize;
 
 	list=graph->set_list;
 	p_x = (g_data_x *) list->data;
+
+/*NEW: process the diffraction case first*/
+if((graph->type==GRAPH_XY_TYPE)&&(graph->wavelength>=0.1)){
+	/*get the y_value first*/
+	y_index=-1;
+	list=g_slist_next(list);
+	for ( ; list ; list=g_slist_next(list)){
+		p_y = (g_data_y *) list->data;
+		for(i=0;i<p_y->y_size;i++){
+			yf = p_y->y[i];
+			yf -= graph->ymin;
+			yf /= (graph->ymax - graph->ymin);
+			yf *= dy;
+			yy = (gint) yf;
+			yy *= -1;
+			yy += oy;
+			if((y>(yy-SEL_SENS))&&(y<(yy+SEL_SENS))){
+				/*got it*/
+				y_index=i;
+				graph->select_2=p_y->y[y_index];
+				break;
+			}
+		}
+	}
+	if(y_index<0){
+		/*not found*/
+		if(graph->select_label!=NULL) g_free(graph->select_label);
+		graph->select_label=NULL;
+		return;
+	}
+if(p_y->y[y_index]<=0.1){
+	/*disable selection of zero background BUT allow the 0-selection of peak*/
+	x_index=-1;
+	y_index=-1;
+	list=graph->set_list;
+	list=g_slist_next(list);
+	p_y = (g_data_y *) list->data;/*there is only one set*/
+	for(i=0;i<p_x->x_size;i++){
+		xf = p_x->x[i];
+		xf -= graph->xmin;
+		xf /= (graph->xmax - graph->xmin);
+		xx = ox + xf*dx;
+		if((x>(xx-SEL_SENS))&&(x<(xx+SEL_SENS))) {
+			x_index=i;
+			if(p_y->y[x_index]<=0.1){
+				/*we are still in the background*/
+				x_index=-1;
+			}else{
+				/*got it*/
+				graph->select=x_index;
+				graph->select_2=0.0;
+				break;
+			}
+		}
+	}
+}else{
+	/*check the x, corresponding to that y*/
+	x_index=-1;
+	xf = p_x->x[y_index];
+	xf -= graph->xmin;
+	xf /= (graph->xmax - graph->xmin);
+	xx = ox + xf*dx;
+	if((x>(xx-SEL_SENS))&&(x<(xx+SEL_SENS))) {
+		/*got it*/
+		x_index=y_index;
+		graph->select=x_index;
+	}
+}
+	if(x_index<0) {
+		/*not found*/
+		if(graph->select_label!=NULL) g_free(graph->select_label);
+		graph->select_label=NULL;
+		return;
+	}
+/*get the proper (h,k,l) peak label*/
+        gdouble xval=p_x->x[x_index];
+        gdouble dhkl, d, dmin;
+        GSList *item, *dlist;
+        struct plane_pak *plane, *plane_min;
+        /*we have a hkl ... maybe?*/
+        dhkl = 0.5 * graph->wavelength / sin(0.5*xval*D2R);
+#if DEBUG_PEAK_SELECT
+printf("Peak seach (%d, %d) : %f (%f) : ", x, y, xval, dhkl);
+#endif
+        dlist = diff_get_ranked_faces(model->diffract.dhkl_min, model);
+        dmin = 1.0;
+        plane_min = NULL;
+        /* Dhkl difference based search */
+        for (item=dlist ; item ; item=g_slist_next(item)){
+                plane = item->data;
+                d = fabs(plane->dhkl - dhkl);
+                if (d < dmin){
+                        plane_min = plane;
+                        dmin = d;
+                }
+        }
+        if (plane_min && dmin < 0.1){
+                gint h, k, l;
+                h = plane_min->index[0];
+                k = plane_min->index[1];
+                l = plane_min->index[2];
+                if(graph->select_label) g_free(graph->select_label);
+                graph->select_label = g_strdup_printf("(%d %d %d)", h, k, l);
+#if DEBUG_PEAK_SELECT
+printf("Dhkl = %f (%f)\n", plane_min->dhkl, dmin);
+#endif
+        }else{
+/*this could happen if within a 2-peaks region but not 0 background*/
+                graph->select_label = g_strdup_printf("[%G,%G]",p_x->x[x_index],p_y->y[x_index]);
+#if DEBUG_PEAK_SELECT
+printf("(none)\n");
+#endif
+        }
+	return;
+}/*end of diffraction*/
 	/*get the corresponding x index*/
 	x_index=-1;
 	for(i=0;i<p_x->x_size;i++){
@@ -605,6 +720,7 @@ if (graph->x_title) oy = canvas->y + canvas->height - 5*gl_fontsize;
 	/*scan for the proper y value*/
 	j=0;y_index=-1;
   if((graph->type==GRAPH_IY_TYPE)||(graph->type==GRAPH_XY_TYPE)){
+	list=g_slist_next(list);
 	for ( ; list ; list=g_slist_next(list)){
 		p_y = (g_data_y *) list->data;
 		yf = p_y->y[x_index];/*only need to look here*/
@@ -619,47 +735,6 @@ if (graph->x_title) oy = canvas->y + canvas->height - 5*gl_fontsize;
 			y_index=1;
 			graph->select=x_index;
 			graph->select_2=p_y->y[x_index];
-/*NEW: add the diffract case*/
-if(graph->wavelength>=0.1){
-	gdouble xval=p_x->x[x_index];
-	gdouble dhkl, d, dmin;
-	GSList *item, *dlist;
-	struct plane_pak *plane, *plane_min;
-	/*we have a hkl ... maybe?*/
-	dhkl = 0.5 * graph->wavelength / sin(0.5*xval*D2R);
-#if DEBUG_PEAK_SELECT
-printf("Peak seach (%d, %d) : %f (%f) : ", x, y, xval, dhkl);
-#endif
-	dlist = diff_get_ranked_faces(model->diffract.dhkl_min, model);
-	dmin = 1.0;
-	plane_min = NULL;
-	/* Dhkl difference based search */
-	for (item=dlist ; item ; item=g_slist_next(item)){
-		plane = item->data;
-		d = fabs(plane->dhkl - dhkl);
-		if (d < dmin){
-			plane_min = plane;
-			dmin = d;
-		}
-	}
-	if (plane_min && dmin < 0.1){
-		gint h, k, l;
-		h = plane_min->index[0];
-		k = plane_min->index[1];
-		l = plane_min->index[2];
-		if(graph->select_label) g_free(graph->select_label);
-		graph->select_label = g_strdup_printf("(%d %d %d)", h, k, l);
-#if DEBUG_PEAK_SELECT
-printf("Dhkl = %f (%f)\n", plane_min->dhkl, dmin);
-#endif
-	}else{
-		graph->select_label = g_strdup_printf("[%G,%G]",p_x->x[x_index],p_y->y[x_index]);
-#if DEBUG_PEAK_SELECT
-printf("(none)\n");
-#endif
-	}
-	break;
-}
 			if(graph->select_label) g_free(graph->select_label);
 			if(graph->type==GRAPH_IY_TYPE) graph->select_label=g_strdup_printf("[%i,%f]",(gint)p_x->x[x_index],p_y->y[x_index]);
 			else graph->select_label=g_strdup_printf("[%G,%G]",p_x->x[x_index],p_y->y[x_index]);

--- a/src/gui_diffract.c
+++ b/src/gui_diffract.c
@@ -418,7 +418,9 @@ dat_graph_set_y_title("intensities (a.u.)",graph);
 /*prepare data*/
 gx.x_size=n;
 gx.x=g_malloc0(gx.x_size*sizeof(gdouble));
-for(idx=0;idx<n;idx++) gx.x[idx]=(gdouble)idx / i;
+gx.x[0]=0.;
+for(idx=1;idx<n;idx++) gx.x[idx]=gx.x[idx-1]+model->diffract.theta[2];
+
 gy.y_size=n;
 gy.y=g_malloc0(gy.y_size*sizeof(gdouble));
 gy.idx=g_malloc0(gy.y_size*sizeof(gint32));
@@ -440,7 +442,7 @@ gy.color=GRAPH_COLOR_DEFAULT;
 dat_graph_set_x(gx,graph);
 dat_graph_add_y(gy,graph);
 dat_graph_set_type(GRAPH_XY_TYPE,graph);
-dat_graph_set_limits(0.,n/i,0.,max,graph);
+dat_graph_set_limits(model->diffract.theta[0],model->diffract.theta[1],0.,max,graph);
 graph_set_yticks(FALSE, 2, graph);
 graph_set_xticks(TRUE, i, graph);
 graph_set_wavelength(model->diffract.wavelength, graph);


### PR DESCRIPTION
This should fix the problem of peak selection.
The problem was a combination of the highly pack diffraction data (900 points for a graph drawn on a comparable number of pixels).
This results, for a 5-pixels selection sensitivity, in the following selection left shift:
![trouble](https://user-images.githubusercontent.com/36496189/61282418-3edd6180-a7f6-11e9-986c-fad1fc4adfc1.jpeg)

Additionally, the ~1 pixel  window for selection was unreachable, as reported by Prof. Rohl.

In this fix, I kept both way of selecting a peak: from baseline or from top value. The reason is that in some few occasions, selecting by top proved to be a fast way to separate 2 very close peaks.
In any case, using the graph interface to change the x axis limits would work equally well.

BTW, I removed the unnecessary selection of ~zero background.
